### PR TITLE
Fix UE Livelink can't evaluate frame for 'Z_Tracker'

### DIFF
--- a/LiveLink_Data_Sender_V1/Python_Source_Code/L_UDP_Packet_Sender.py
+++ b/LiveLink_Data_Sender_V1/Python_Source_Code/L_UDP_Packet_Sender.py
@@ -8,7 +8,7 @@ all_lines = file.readlines()
 #-------------------------------------------------------------------------------------#
 UDP_IP = str(all_lines[3].strip())
 UDP_PORT = int(all_lines[4].strip())
-PREFIX = bytes.fromhex("F2")
+#PREFIX = bytes.fromhex("F2")
 #MESSAGE = ",Hello,1,2,3,4,5,6"
 #BUFFER = PREFIX + bytes(MESSAGE, "utf-8")
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -36,9 +36,9 @@ with SERIAL_COM as ser:
         ser.flush()
         while True:
             try:
-                reading = ser.readline().decode('utf-8')
+                reading = ser.readline().decode('utf-8').strip()
 
-                BUFFER = PREFIX + bytes(reading, "utf-8")
+                BUFFER = bytes(reading, "utf-8")
                 sock.sendto(BUFFER, (UDP_IP, UDP_PORT)) 
                 print(BUFFER)
             except:


### PR DESCRIPTION
remove PREFIX and '\r\n' from the UDP Livelink message